### PR TITLE
Fixed wrap around for sample value of 1

### DIFF
--- a/ndarray-wav.js
+++ b/ndarray-wav.js
@@ -117,7 +117,7 @@ var writeWav = exports.write = function (wavFile, wavData, options, callback) {
 			for (var sampleNum = 0; sampleNum < samples; sampleNum++) {
 				for (var channelNum = 0; channelNum < channels; channelNum++) {
 					var value = wavData.get(channelNum, sampleNum);
-					if (value > 1) {
+					if (value >= 1) {
 						value = 32767
 					} else if (value <= -1) {
 						value = 32768;


### PR DESCRIPTION
If sample value is 1, it should be encoded as 32767 not 32768
